### PR TITLE
feat(lint): add lint-config.sh for unified local and CI configuration

### DIFF
--- a/.github/workflows/_lint.yaml
+++ b/.github/workflows/_lint.yaml
@@ -4,27 +4,6 @@ name: Lint (Reusable)
 
 on:
   workflow_call:
-    inputs:
-      megalinter-image:
-        description: "Custom MegaLinter Docker image"
-        type: string
-        required: false
-        default: ""
-      megalinter-flavor:
-        description: "MegaLinter flavor (all, javascript, python, etc.)"
-        type: string
-        required: false
-        default: "all"
-      validate-all-codebase:
-        description: "Validate entire codebase (not just changed files)"
-        type: boolean
-        required: false
-        default: false
-      skip-bot-commits:
-        description: "Skip linting for renovate/dependabot commits"
-        type: boolean
-        required: false
-        default: true
 
 jobs:
   lint:
@@ -34,56 +13,12 @@ jobs:
       group: ${{ github.workflow }}-lint-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Check if should skip
-        id: check-skip
-        env:
-          SKIP_BOT_COMMITS: ${{ inputs.skip-bot-commits }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          if [[ "$SKIP_BOT_COMMITS" == "true" && ("$ACTOR" == "renovate[bot]" || "$ACTOR" == "dependabot[bot]") ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping lint for bot commit"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout
-        if: steps.check-skip.outputs.skip != 'true'
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 0
 
-      - name: Set MegaLinter image
-        if: steps.check-skip.outputs.skip != 'true'
-        id: set-image
-        env:
-          CUSTOM_IMAGE: ${{ inputs.megalinter-image }}
-          FLAVOR: ${{ inputs.megalinter-flavor }}
-        run: |
-          if [ -n "$CUSTOM_IMAGE" ]; then
-            echo "image=$CUSTOM_IMAGE" >> "$GITHUB_OUTPUT"
-          else
-            echo "image=oxsecurity/megalinter-$FLAVOR:v8" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Run MegaLinter
-        if: steps.check-skip.outputs.skip != 'true'
-        id: megalinter
         env:
-          MEGALINTER_IMAGE: ${{ steps.set-image.outputs.image }}
-          MEGALINTER_FLAVOR: ${{ inputs.megalinter-flavor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: ${{ inputs.validate-all-codebase && 'true' || 'false' }}
-        run: |
-          docker run \
-            -e MEGALINTER_FLAVOR \
-            -e GITHUB_TOKEN \
-            -e VALIDATE_ALL_CODEBASE \
-            -e DEFAULT_WORKSPACE=/tmp/lint \
-            -e GITHUB_REPOSITORY="${{ github.repository }}" \
-            -e GITHUB_SHA="${{ github.sha }}" \
-            -e GITHUB_REF="${{ github.ref }}" \
-            -e GITHUB_RUN_ID="${{ github.run_id }}" \
-            -v "${{ github.workspace }}:/tmp/lint:rw" \
-            --rm \
-            "$MEGALINTER_IMAGE"
+        run: ./lint.sh --ci

--- a/lint-config.sh
+++ b/lint-config.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Lint configuration - customize per repository
+# This file is sourced by lint.sh for both local and CI runs
+
+# MegaLinter Docker image (use digest for reproducibility)
+# renovate: TODO
+MEGALINTER_IMAGE="ghcr.io/anthony-spruyt/megalinter-container-images@sha256:575587d9caf54235888e3749734aec1ef094bdbd876dd0e0c88f443114a415ee"
+
+# Validate entire codebase vs changed files only
+VALIDATE_ALL_CODEBASE=false
+
+# Skip linting for renovate/dependabot commits in CI
+SKIP_BOT_COMMITS=true
+
+# MegaLinter flavor (use "all" for custom images to bypass flavor validation)
+MEGALINTER_FLAVOR="all"

--- a/lint.sh
+++ b/lint.sh
@@ -1,38 +1,63 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Runs mega-linter against the repository.
-# Can be run from any directory.
+# Runs MegaLinter against the repository.
+# Usage:
+#   ./lint.sh       - Local mode (with fixes, user permissions)
+#   ./lint.sh --ci  - CI mode (no fixes, passes GitHub env vars)
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# TODO: update to default image / default custom flavor
-MEGALINTER_IMAGE="ghcr.io/anthony-spruyt/megalinter-container-images@sha256:575587d9caf54235888e3749734aec1ef094bdbd876dd0e0c88f443114a415ee"
-# MEGALINTER_FLAVOR=all bypasses flavor validation (custom flavors aren't recognized)
-MEGALINTER_FLAVOR="all"
 
-rm -rf "$REPO_ROOT/.output"
-mkdir "$REPO_ROOT/.output"
+# Source config file (required)
+# shellcheck source=lint-config.sh
+source "$REPO_ROOT/lint-config.sh"
 
-docker run \
-  -a STDOUT \
-  -a STDERR \
-  -u "$(id -u):$(id -g)" \
-  -w /tmp/lint \
-  -e HOME=/tmp \
-  -e MEGALINTER_FLAVOR=$MEGALINTER_FLAVOR \
-  -e APPLY_FIXES="all" \
-  -e UPDATED_SOURCES_REPORTER="true" \
-  -e REPORT_OUTPUT_FOLDER="/tmp/lint/.output" \
-  -v "$REPO_ROOT:/tmp/lint:rw" \
-  --rm \
-  $MEGALINTER_IMAGE
+if [[ "${1:-}" == "--ci" ]]; then
+  # CI mode
+  # Skip bot commits if configured
+  if [[ "$SKIP_BOT_COMMITS" == "true" && ("${GITHUB_ACTOR:-}" == "renovate[bot]" || "${GITHUB_ACTOR:-}" == "dependabot[bot]") ]]; then
+    echo "::notice::Skipping lint for bot commit"
+    exit 0
+  fi
 
-# Capture MegaLinter exit code
-LINT_EXIT_CODE=$?
+  docker run \
+    -e MEGALINTER_FLAVOR="$MEGALINTER_FLAVOR" \
+    -e GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
+    -e VALIDATE_ALL_CODEBASE="$VALIDATE_ALL_CODEBASE" \
+    -e DEFAULT_WORKSPACE=/tmp/lint \
+    -e GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}" \
+    -e GITHUB_SHA="${GITHUB_SHA:-}" \
+    -e GITHUB_REF="${GITHUB_REF:-}" \
+    -e GITHUB_RUN_ID="${GITHUB_RUN_ID:-}" \
+    -v "$REPO_ROOT:/tmp/lint:rw" \
+    --rm \
+    "$MEGALINTER_IMAGE"
+else
+  # Local mode - with fixes and user permissions
+  rm -rf "$REPO_ROOT/.output"
+  mkdir "$REPO_ROOT/.output"
 
-# Copy fixed files back to workspace
-if compgen -G "$REPO_ROOT/.output/updated_sources/*" >/dev/null; then
-  cp -r "$REPO_ROOT/.output/updated_sources"/* "$REPO_ROOT/"
+  docker run \
+    -a STDOUT \
+    -a STDERR \
+    -u "$(id -u):$(id -g)" \
+    -w /tmp/lint \
+    -e HOME=/tmp \
+    -e MEGALINTER_FLAVOR="$MEGALINTER_FLAVOR" \
+    -e VALIDATE_ALL_CODEBASE="$VALIDATE_ALL_CODEBASE" \
+    -e APPLY_FIXES="all" \
+    -e UPDATED_SOURCES_REPORTER="true" \
+    -e REPORT_OUTPUT_FOLDER="/tmp/lint/.output" \
+    -v "$REPO_ROOT:/tmp/lint:rw" \
+    --rm \
+    "$MEGALINTER_IMAGE"
+
+  LINT_EXIT_CODE=$?
+
+  # Copy fixed files back to workspace
+  if compgen -G "$REPO_ROOT/.output/updated_sources/*" >/dev/null; then
+    cp -r "$REPO_ROOT/.output/updated_sources"/* "$REPO_ROOT/"
+  fi
+
+  exit $LINT_EXIT_CODE
 fi
-
-exit $LINT_EXIT_CODE

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -76,6 +76,10 @@ files:
       - Project-specific MegaLinter configuration
       - Extends the base config from repo-operator
       - Add custom linters or overrides below
+      - "Add project-specific linters below:"
+      - "ENABLE_LINTERS:"
+      - "  - TYPESCRIPT_ES"
+      - "  - PYTHON_PYLINT"
     content: "@templates/.mega-linter.yml"
   .pre-commit-config.yaml:
     schemaUrl: https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/pre-commit-config.json
@@ -84,6 +88,7 @@ files:
     createOnly: true
   .prettierrc.yaml:
     schemaUrl: https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/prettierrc.json
+    header: This file is automatically updated - do not modify directly
     content: "@templates/.prettierrc.yaml"
   .shellcheckrc:
     createOnly: true
@@ -95,14 +100,20 @@ files:
     content: "@templates/.trivyignore.yaml"
   .yamllint.yml:
     schemaUrl: https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/yamllint.json
-    header: https://yamllint.readthedocs.io/en/latest/configuration.html
+    header:
+      - This file is automatically updated - do not modify directly
+      - https://yamllint.readthedocs.io/en/latest/configuration.html
     content: "@templates/.yamllint.yml"
   LICENSE:
     content: "@templates/LICENSE.MIT"
-  lint.sh:
+  lint-config.sh:
     createOnly: true
+    content: "@templates/lint-config.sh"
+  lint.sh:
     content: "@templates/lint.sh"
   trivy.yaml:
     schemaUrl: https://raw.githubusercontent.com/aquasecurity/trivy/main/schema/trivy-config.json
-    header: https://trivy.dev/latest/docs/references/configuration/config-file/
+    header:
+      - This file is automatically updated - do not modify directly
+      - https://trivy.dev/latest/docs/references/configuration/config-file/
     content: "@templates/trivy.yaml"

--- a/src/templates/.devcontainer/package.json
+++ b/src/templates/.devcontainer/package.json
@@ -1,4 +1,5 @@
 {
+  "$generated": "This file is automatically updated - do not modify directly",
   "$schema": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/package.json",
   "name": "devcontainer-tools",
   "private": true,

--- a/src/templates/.devcontainer/post-create.sh
+++ b/src/templates/.devcontainer/post-create.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+# This file is automatically updated - do not modify directly
+
 # Make all shell scripts executable (runs from repo root via postCreateCommand)
 find . -type f -name '*.sh' -exec chmod +x {} +
 

--- a/src/templates/.devcontainer/verify-setup.sh
+++ b/src/templates/.devcontainer/verify-setup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
+# This file is automatically updated - do not modify directly
+
 # Devcontainer setup verification tests
 
 PASSED=0

--- a/src/templates/.editorconfig
+++ b/src/templates/.editorconfig
@@ -1,3 +1,4 @@
+# This file is automatically updated - do not modify directly
 root = true
 
 [*]

--- a/src/templates/.github/apply-rulesets.sh
+++ b/src/templates/.github/apply-rulesets.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# This file is automatically updated - do not modify directly
+
 # Apply repository rulesets from .github/rulesets/*.json
 # Requires: gh CLI authenticated with repo admin permissions
 

--- a/src/templates/.github/rulesets/pr-rules.json
+++ b/src/templates/.github/rulesets/pr-rules.json
@@ -1,4 +1,5 @@
 {
+  "$generated": "This file is automatically updated - do not modify directly",
   "name": "pr-rules",
   "target": "branch",
   "enforcement": "active",

--- a/src/templates/.github/rulesets/push-protection.json
+++ b/src/templates/.github/rulesets/push-protection.json
@@ -1,4 +1,5 @@
 {
+  "$generated": "This file is automatically updated - do not modify directly",
   "name": "push-protection",
   "target": "branch",
   "enforcement": "active",

--- a/src/templates/.github/workflows/ci.yaml
+++ b/src/templates/.github/workflows/ci.yaml
@@ -18,12 +18,6 @@ permissions:
 jobs:
   lint:
     uses: anthony-spruyt/repo-operator/.github/workflows/_lint.yaml@main
-    with:
-      # Customize MegaLinter options per repository:
-      # megalinter-image: "ghcr.io/your-org/your-megalinter-image:tag"
-      # megalinter-flavor: "javascript"
-      # validate-all-codebase: false
-      skip-bot-commits: true
     secrets: inherit
 
   # Add your repository-specific jobs here:
@@ -34,7 +28,7 @@ jobs:
   #     - run: npm ci && npm run build
 
   # security:
-  #   uses: anthony-spruyt/repo-operator/.github/workflows/_security.yaml@main
+  #   uses: anthony-spruyt/repo-operator/.github/workflows/_lint.yaml@main
   #   secrets: inherit
 
   # Summary job for branch protection - add jobs to 'needs' array

--- a/src/templates/.markdownlint.json
+++ b/src/templates/.markdownlint.json
@@ -1,4 +1,5 @@
 {
+  "$generated": "This file is automatically updated - do not modify directly",
   "$schema": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/prettierrc.json",
   "MD004": false,
   "MD007": {

--- a/src/templates/lint-config.sh
+++ b/src/templates/lint-config.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Lint configuration - customize per repository
+# This file is sourced by lint.sh for both local and CI runs
+
+# MegaLinter Docker image (use digest for reproducibility)
+# renovate: TODO
+MEGALINTER_IMAGE="ghcr.io/anthony-spruyt/megalinter-container-images@sha256:575587d9caf54235888e3749734aec1ef094bdbd876dd0e0c88f443114a415ee"
+
+# Validate entire codebase vs changed files only
+VALIDATE_ALL_CODEBASE=false
+
+# Skip linting for renovate/dependabot commits in CI
+SKIP_BOT_COMMITS=true
+
+# MegaLinter flavor (use "all" for custom images to bypass flavor validation)
+MEGALINTER_FLAVOR="all"

--- a/src/templates/lint.sh
+++ b/src/templates/lint.sh
@@ -1,38 +1,65 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Runs mega-linter against the repository.
-# Can be run from any directory.
+# This file is automatically updated - do not modify directly
+
+# Runs MegaLinter against the repository.
+# Usage:
+#   ./lint.sh       - Local mode (with fixes, user permissions)
+#   ./lint.sh --ci  - CI mode (no fixes, passes GitHub env vars)
 
 REPO_ROOT="$(cd "$(dirname "$${BASH_SOURCE[0]}")" && pwd)"
-# TODO: update to default image / default custom flavor
-MEGALINTER_IMAGE="ghcr.io/anthony-spruyt/megalinter-container-images@sha256:575587d9caf54235888e3749734aec1ef094bdbd876dd0e0c88f443114a415ee"
-# MEGALINTER_FLAVOR=all bypasses flavor validation (custom flavors aren't recognized)
-MEGALINTER_FLAVOR="all"
 
-rm -rf "$REPO_ROOT/.output"
-mkdir "$REPO_ROOT/.output"
+# Source config file (required)
+# shellcheck source=lint-config.sh
+source "$REPO_ROOT/lint-config.sh"
 
-docker run \
-  -a STDOUT \
-  -a STDERR \
-  -u "$(id -u):$(id -g)" \
-  -w /tmp/lint \
-  -e HOME=/tmp \
-  -e MEGALINTER_FLAVOR=$MEGALINTER_FLAVOR \
-  -e APPLY_FIXES="all" \
-  -e UPDATED_SOURCES_REPORTER="true" \
-  -e REPORT_OUTPUT_FOLDER="/tmp/lint/.output" \
-  -v "$REPO_ROOT:/tmp/lint:rw" \
-  --rm \
-  $MEGALINTER_IMAGE
+if [[ "$${1:-}" == "--ci" ]]; then
+  # CI mode
+  # Skip bot commits if configured
+  if [[ "$SKIP_BOT_COMMITS" == "true" && ("$${GITHUB_ACTOR:-}" == "renovate[bot]" || "$${GITHUB_ACTOR:-}" == "dependabot[bot]") ]]; then
+    echo "::notice::Skipping lint for bot commit"
+    exit 0
+  fi
 
-# Capture MegaLinter exit code
-LINT_EXIT_CODE=$?
+  docker run \
+    -e MEGALINTER_FLAVOR="$MEGALINTER_FLAVOR" \
+    -e GITHUB_TOKEN="$${GITHUB_TOKEN:-}" \
+    -e VALIDATE_ALL_CODEBASE="$VALIDATE_ALL_CODEBASE" \
+    -e DEFAULT_WORKSPACE=/tmp/lint \
+    -e GITHUB_REPOSITORY="$${GITHUB_REPOSITORY:-}" \
+    -e GITHUB_SHA="$${GITHUB_SHA:-}" \
+    -e GITHUB_REF="$${GITHUB_REF:-}" \
+    -e GITHUB_RUN_ID="$${GITHUB_RUN_ID:-}" \
+    -v "$REPO_ROOT:/tmp/lint:rw" \
+    --rm \
+    "$MEGALINTER_IMAGE"
+else
+  # Local mode - with fixes and user permissions
+  rm -rf "$REPO_ROOT/.output"
+  mkdir "$REPO_ROOT/.output"
 
-# Copy fixed files back to workspace
-if compgen -G "$REPO_ROOT/.output/updated_sources/*" >/dev/null; then
-  cp -r "$REPO_ROOT/.output/updated_sources"/* "$REPO_ROOT/"
+  docker run \
+    -a STDOUT \
+    -a STDERR \
+    -u "$(id -u):$(id -g)" \
+    -w /tmp/lint \
+    -e HOME=/tmp \
+    -e MEGALINTER_FLAVOR="$MEGALINTER_FLAVOR" \
+    -e VALIDATE_ALL_CODEBASE="$VALIDATE_ALL_CODEBASE" \
+    -e APPLY_FIXES="all" \
+    -e UPDATED_SOURCES_REPORTER="true" \
+    -e REPORT_OUTPUT_FOLDER="/tmp/lint/.output" \
+    -v "$REPO_ROOT:/tmp/lint:rw" \
+    --rm \
+    "$MEGALINTER_IMAGE"
+
+  LINT_EXIT_CODE=$?
+
+  # Copy fixed files back to workspace
+  if compgen -G "$REPO_ROOT/.output/updated_sources/*" >/dev/null; then
+    cp -r "$REPO_ROOT/.output/updated_sources"/* "$REPO_ROOT/"
+  fi
+
+  exit $LINT_EXIT_CODE
 fi
-
-exit $LINT_EXIT_CODE


### PR DESCRIPTION
## Summary

- Add `lint-config.sh` as single source of truth for lint settings (image, flavor, validate-all, skip-bots)
- Rewrite `lint.sh` with `--ci` flag for mode switching (local vs CI)
- Simplify `_lint.yaml` to just call `./lint.sh --ci` (removes all workflow inputs)
- Remove workflow inputs from `ci.yaml` template
- Add "auto-updated" headers to synced template files

## Test plan

- [ ] Run `./lint.sh` locally - should apply fixes with user permissions
- [ ] Run `./lint.sh --ci` locally - should run without fixes
- [ ] Push to trigger CI - workflow should call `./lint.sh --ci`
- [ ] Change `MEGALINTER_IMAGE` in `lint-config.sh` - both modes should use new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)