### PR TITLE
feat(renovate): add Terraform Docker image custom managers

### DIFF
--- a/.github/renovate/custom-managers/annotated.json5
+++ b/.github/renovate/custom-managers/annotated.json5
@@ -85,6 +85,27 @@
       ],
       datasourceTemplate: "docker",
       versioningTemplate: "docker"
+    },
+    // Terraform: Docker image string with optional digest
+    {
+      customType: "regex",
+      description: ["Annotated Terraform Docker image (depName first)."],
+      managerFilePatterns: ["/\\.tf$/"],
+      matchStrings: [
+        "#\\s*renovate:\\s*depName=(?<depName>\\S+)\\s+datasource=docker\\n\\s*\\w+\\s*=\\s*\"[^:]+:(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[^\"]+))?\""
+      ],
+      datasourceTemplate: "docker",
+      versioningTemplate: "docker"
+    },
+    {
+      customType: "regex",
+      description: ["Annotated Terraform Docker image (datasource first)."],
+      managerFilePatterns: ["/\\.tf$/"],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=docker\\s+depName=(?<depName>\\S+)\\n\\s*\\w+\\s*=\\s*\"[^:]+:(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[^\"]+))?\""
+      ],
+      datasourceTemplate: "docker",
+      versioningTemplate: "docker"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Extend annotated custom managers to detect Docker image strings in Terraform `.tf` files
- Supports both `depName=... datasource=docker` and `datasource=docker depName=...` ordering
- Captures optional `@sha256` digest

## Motivation
Spruyt-labs Coder templates (`cluster/apps/coder-system/coder-template-sync/app/templates/**/main.tf`) pin `ghcr.io/coder/envbuilder` via `coder_parameter` defaults. Without this, `.tf` image pins go untracked by Renovate.

## Test plan
- [x] `renovate-config-validator --strict .github/renovate/custom-managers/annotated.json5` passes
- [ ] After merge: confirm Renovate dry-run in spruyt-labs detects pinned envbuilder image