### PR TITLE
fix(renovate): change rebaseWhen to conflicted

### DIFF
--- a/.github/renovate/base.json5
+++ b/.github/renovate/base.json5
@@ -14,7 +14,7 @@
   dependencyDashboardTitle: "Renovate Dashboard",
   suppressNotifications: ["prIgnoreNotification"],
   commitBodyTable: true,
-  rebaseWhen: "behind-base-branch",
+  rebaseWhen: "conflicted",
   hostRules: [
     {
       description: "Prevent GCR metadata token negotiation failures on hosted Renovate",


### PR DESCRIPTION
## Summary
- Change `rebaseWhen` from `behind-base-branch` to `conflicted` in Renovate base config
- Prevents Renovate from rebasing PRs that are simply behind main, which conflicts with Mergify merge queues

## Linked Issue
Closes #136

## Changes
- `.github/renovate/base.json5`: `rebaseWhen: "conflicted"`

## Testing
- Merge multiple Renovate PRs via Mergify queue — queued PRs should no longer get dequeued by Renovate rebases
- PRs with actual merge conflicts will still be rebased by Renovate

🤖 Generated with [Claude Code](https://claude.com/claude-code)