### PR TITLE
chore(renovate): enable digest pinning for Flux OCI sources

### DIFF
--- a/.github/renovate/package-rules.json5
+++ b/.github/renovate/package-rules.json5
@@ -173,10 +173,10 @@
       addLabels: ["renovate/flux"]
     },
     {
-      description: "Disable digest pinning for Flux manager on OCI sources (Flux manager cannot insert digest field into OCIRepository spec/ref)",
+      description: "Enable digest pinning for Flux manager on OCI sources (Renovate >= v43.142.1 supports updating existing digest fields in OCIRepository spec/ref)",
       matchManagers: ["flux"],
       matchDatasources: ["docker", "oci"],
-      pinDigests: false
+      pinDigests: true
     },
     {
       matchManagers: ["kubernetes"],


### PR DESCRIPTION
## Summary
- Flip `pinDigests: false` → `true` for `matchManagers: ["flux"]` + `matchDatasources: ["docker", "oci"]`
- Renovate v43.142.1+ (merged 2026-04-27 via [renovatebot/renovate#41882](https://github.com/renovatebot/renovate/pull/41882)) can now update existing `digest` fields in Flux `OCIRepository` `spec/ref`

## Linked Issue
Ref anthony-spruyt/spruyt-labs#1300

## Changes
- Updated description to reflect new capability
- Changed `pinDigests` from `false` to `true`

## Testing
- Companion PR in spruyt-labs adds initial `digest:` fields to all 12 OCIRepository manifests
- After both merge, Renovate will maintain tag+digest atomically on future bumps
- Rollback: revert this change and remove `digest:` fields from OCIRepository manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)