### PR TITLE
chore(renovate): add create-only overrides file for repo-specific rules

### DIFF
--- a/.github/renovate/package-rules.json5
+++ b/.github/renovate/package-rules.json5
@@ -43,50 +43,6 @@
       enabled: false
     },
 
-    // ============ Repo-specific rules ============
-    {
-      description: "Coder uses two-channel releases (mainline/stable); 30-day delay avoids adopting unproven mainline versions",
-      matchRepositories: ["anthony-spruyt/spruyt-labs"],
-      matchPackageNames: ["coder"],
-      matchDatasources: ["helm"],
-      minimumReleaseAge: "30 days"
-    },
-    {
-      description: "Weekly batch for all non-major updates in container-images (excludes named groups)",
-      matchRepositories: ["anthony-spruyt/container-images"],
-      matchUpdateTypes: ["minor", "patch", "digest", "pin", "pinDigest"],
-      matchPackageNames: [
-        "!kubernetes",
-        "!kubernetes/kubernetes",
-        "!siderolabs/talos",
-        "!ghcr.io/siderolabs/installer",
-        "!ghcr.io/siderolabs/kubelet",
-        "!bitnami/kubectl",
-        "!public.ecr.aws/bitnami/kubectl",
-        "!alpine/k8s",
-        "!cilium",
-        "!cilium/cilium-cli",
-        "!cilium/hubble",
-        "!quay.io/cilium/cilium",
-        "!quay.io/cilium/operator-generic"
-      ],
-      schedule: ["before 9am on monday"],
-      groupName: "weekly-dependencies",
-      group: {
-        commitMessageTopic: "weekly dependency updates"
-      }
-    },
-
-    // ============ Kustomize postRenderers (version managed via newTag, not inline) ============
-    {
-      description: "Disable kubernetes manager pinDigest for images whose tag is set by kustomize images transformer (bare image in patch string, version tracked via annotated newTag)",
-      matchRepositories: ["anthony-spruyt/spruyt-labs"],
-      matchManagers: ["kubernetes"],
-      matchPackageNames: ["n8nio/runners"],
-      pinDigests: false,
-      enabled: false
-    },
-
     // ============ Docker/OCI ============
     {
       matchDatasources: ["docker", "oci"],
@@ -131,15 +87,6 @@
       matchDatasources: ["helm"],
       matchUpdateTypes: ["patch"],
       labels: ["renovate/helm", "dep/patch"]
-    },
-
-    // ============ Dockerfile ARG dedup ============
-    {
-      description: "Disable dockerfile manager for golang in spruyt-labs (ARG interpolation breaks updates; custom.regex manager handles these via annotations)",
-      matchRepositories: ["anthony-spruyt/spruyt-labs"],
-      matchManagers: ["dockerfile"],
-      matchPackageNames: ["golang"],
-      enabled: false
     },
 
     // ============ Managers ============

--- a/src/groups.yaml
+++ b/src/groups.yaml
@@ -236,6 +236,10 @@ groups:
               version: "43.122.0"
       .github/renovate.json5:
         content: "@templates/.github/renovate.json5"
+      .github/renovate-overrides.json5:
+        createOnly: true
+        header: Repo-specific Renovate overrides — customize freely, xfg will not overwrite
+        content: "@templates/.github/renovate-overrides.json5"
     settings:
       labels:
         "renovate/devcontainer":

--- a/src/templates/.github/renovate-overrides.json5
+++ b/src/templates/.github/renovate-overrides.json5
@@ -1,0 +1,4 @@
+// Repo-specific Renovate overrides — not synced after creation
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json"
+}

--- a/src/templates/.github/renovate.json5
+++ b/src/templates/.github/renovate.json5
@@ -10,6 +10,7 @@
     "github>anthony-spruyt/repo-operator//.github/renovate/groups.json5",
     "github>anthony-spruyt/repo-operator//.github/renovate/automerge.json5",
     "github>anthony-spruyt/repo-operator//.github/renovate/custom-datasources.json5",
-    "github>anthony-spruyt/repo-operator//.github/renovate/disabled.json5"
+    "github>anthony-spruyt/repo-operator//.github/renovate/disabled.json5",
+    "local>.github/renovate-overrides"
   ]
 }


### PR DESCRIPTION
## Summary
- Add `renovate-overrides.json5` as a `createOnly` template that repos can customize without xfg overwriting
- Extend it last in `renovate.json5` for correct last-match-wins semantics
- Remove 4 repo-specific `matchRepositories` package rules from shared config (Coder release age, container-images weekly batch, n8nio/runners pinDigest disable, golang dockerfile disable)

## Linked Issue
Closes #142

## Changes
- **New file:** `src/templates/.github/renovate-overrides.json5` — empty schema-only template
- **`src/templates/.github/renovate.json5`** — added `local>.github/renovate-overrides` as last extends entry
- **`src/groups.yaml`** — added overrides file to renovate group with `createOnly: true`
- **`.github/renovate/package-rules.json5`** — removed 4 `matchRepositories` rules that will move to per-repo overrides

## Testing
- Verify Renovate validates the updated config (`renovate-config-validator`)
- Confirm xfg creates `renovate-overrides.json5` in target repos on next sync
- Confirm xfg does not overwrite existing `renovate-overrides.json5` on subsequent syncs
- Verify removed rules can be re-added in target repo overrides files