### PR TITLE
fix(security): add IP/CIDR leakage prevention to gitleaks template

### DIFF
--- a/src/files.yaml
+++ b/src/files.yaml
@@ -27,7 +27,6 @@ files:
       - https://yamllint.readthedocs.io/en/latest/configuration.html
     content: "@templates/.yamllint.yml"
   .gitleaks.toml:
-    createOnly: true
     content: "@templates/.gitleaks.toml"
   .vscode/settings.json:
     createOnly: true

--- a/src/templates/.gitleaks.toml
+++ b/src/templates/.gitleaks.toml
@@ -5,3 +5,57 @@
 # Extend the default gitleaks config
 # https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 useDefault = true
+
+# --- Global Allowlists ---
+# Repo-specific paths consolidated here for central management.
+[allowlist]
+paths = [
+  # spruyt-labs: ExternalSecret CRDs contain key references, not secret values
+  '''external-secret\.yaml$''',
+  # xfg: Test fixture files with non-sensitive test RSA keys
+  '''test/fixtures/test-fixtures\.ts$''',
+  '''fixtures/test-fixtures\.ts$''',
+  # Hookify rules contain example IPs in documentation
+  '''\.claude/hookify\..*\.local\.md$''',
+  # Hookify test cases contain example IPs for testing
+  '''tests/hooks/hookify_test_cases\.yaml$''',
+]
+
+# --- IP/CIDR Leakage Prevention ---
+# Prevents private IP addresses from being committed to public repositories.
+
+[[rules]]
+id = "private-ip-rfc1918-10"
+description = "RFC1918 private IP address (10.x.x.x)"
+regex = '''(?:^|[^0-9])10\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})(?:/[0-9]{1,2})?(?:[^0-9]|$)'''
+tags = ["ip-leakage"]
+
+  [rules.allowlist]
+  paths = [
+    '''talos/''',
+    '''\.sops\.yaml$''',
+  ]
+
+[[rules]]
+id = "private-ip-rfc1918-172"
+description = "RFC1918 private IP address (172.16-31.x.x)"
+regex = '''(?:^|[^0-9])172\.(?:1[6-9]|2[0-9]|3[01])\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})(?:/[0-9]{1,2})?(?:[^0-9]|$)'''
+tags = ["ip-leakage"]
+
+  [rules.allowlist]
+  paths = [
+    '''talos/''',
+    '''\.sops\.yaml$''',
+  ]
+
+[[rules]]
+id = "private-ip-rfc1918-192"
+description = "RFC1918 private IP address (192.168.x.x)"
+regex = '''(?:^|[^0-9])192\.168\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})(?:/[0-9]{1,2})?(?:[^0-9]|$)'''
+tags = ["ip-leakage"]
+
+  [rules.allowlist]
+  paths = [
+    '''talos/''',
+    '''\.sops\.yaml$''',
+  ]


### PR DESCRIPTION
## Summary
- Add RFC1918 IP detection rules to gitleaks template (10.x, 172.16-31.x, 192.168.x)
- Consolidate all repo-specific allowlists into template
- Remove `createOnly` flag so changes sync to existing repos

## Linked Issue
Ref anthony-spruyt/spruyt-labs#1463

## Changes
- `src/templates/.gitleaks.toml`: IP rules + consolidated allowlists
- `src/files.yaml`: removed `createOnly: true` from `.gitleaks.toml`

## Testing
- Template validated as valid TOML
- Per-rule allowlists for `talos/` and `*.sops.yaml` prevent false positives in spruyt-labs
- Global allowlists cover existing repo-specific exemptions (external-secret.yaml, xfg test fixtures)

## Impact
Next xfg sync will push updated `.gitleaks.toml` to ALL target repos, replacing their existing configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)