### PR TITLE
feat(devcontainer): pass NEXUS_DOCKER_URL into container env

### DIFF
--- a/src/templates/.devcontainer/devcontainer.json
+++ b/src/templates/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
   ],
   "containerEnv": {
     "SSH_AUTH_SOCK": "/ssh-agent",
-    "NEXUS_DOCKER_URL": "${localEnv:NEXUS_DOCKER_URL}"
+    "NEXUS_DOCKER_URL": "$${localEnv:NEXUS_DOCKER_URL}"
   },
   "features": {
   },

--- a/src/templates/.devcontainer/devcontainer.json
+++ b/src/templates/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
     "source=$${localWorkspaceFolderBasename}-containers,target=/var/lib/containers,type=volume"
   ],
   "containerEnv": {
-    "SSH_AUTH_SOCK": "/ssh-agent"
+    "SSH_AUTH_SOCK": "/ssh-agent",
+    "NEXUS_DOCKER_URL": "${localEnv:NEXUS_DOCKER_URL}"
   },
   "features": {
   },


### PR DESCRIPTION
## Summary
- Add `NEXUS_DOCKER_URL` to `containerEnv` in devcontainer.json template
- Uses `${localEnv:NEXUS_DOCKER_URL}` — resolves to empty if not set (no-op)
- Works in conjunction with container-images post-create.sh change that writes podman mirror config when var is present

## Linked Issue
N/A

## Changes
- devcontainer.json template: add `NEXUS_DOCKER_URL` to `containerEnv`

## Testing
- Set `NEXUS_DOCKER_URL=nexus-docker.lan.spruyt.xyz` in Windows environment
- Rebuild devcontainer — podman pulls route through Nexus docker-group proxy
- Without env var set: no change in behaviour
